### PR TITLE
Remove homebrew-tap setting because updates in the homebrew-tap repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,23 +42,6 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-brews:
-  -
-    name: control-controls
-    tap:
-      owner: pepabo
-      name: homebrew-tap
-    commit_author:
-      name: 'GMO Pepabo, inc.'
-    homepage: https://github.com/pepabo/control-controls
-    description: control-controls control controls of AWS Security Hub across all regions.
-    license: MIT
-    install: |
-      bin.install 'control-controls'
-      output = Utils.safe_popen_read("#{bin}/control-controls", 'completion', 'bash')
-      (bash_completion/'control-controls').write output
-      output = Utils.safe_popen_read("#{bin}/control-controls", 'completion', 'zsh')
-      (zsh_completion/'_control-controls').write output
 nfpms:
   -
     id: control-controls-nfpms


### PR DESCRIPTION
ref: https://github.com/pepabo/homebrew-tap/pull/1