### PR TITLE
introduce the --dryrun option to the notify command 

### DIFF
--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -33,6 +33,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var dryrun bool
+
 var notifyCmd = &cobra.Command{
 	Use:   "notify [CONFIG_FILE]",
 	Short: "notify",
@@ -68,7 +70,7 @@ var notifyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := hub.Notify(ctx, cfg, findings); err != nil {
+		if err := hub.Notify(ctx, cfg, findings, dryrun); err != nil {
 			return err
 		}
 		return nil
@@ -78,6 +80,8 @@ var notifyCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(notifyCmd)
 	notifyCmd.Flags().StringSliceVarP(&overlays, "overlay", "", []string{}, "patch file or directory for overlaying")
+	notifyCmd.Flags().BoolVarP(&dryrun, "stdout", "s", false, "output notifications to stdout")
+
 }
 
 func collectActiveFindings(ctx context.Context, cfg aws.Config) ([]sechub.NotifyFinding, error) {

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -80,7 +80,7 @@ var notifyCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(notifyCmd)
 	notifyCmd.Flags().StringSliceVarP(&overlays, "overlay", "", []string{}, "patch file or directory for overlaying")
-	notifyCmd.Flags().BoolVarP(&dryrun, "stdout", "s", false, "output notifications to stdout")
+	notifyCmd.Flags().BoolVarP(&dryrun, "dryrun", "s", false, "output notifications to stdout")
 
 }
 

--- a/sechub/notify_test.go
+++ b/sechub/notify_test.go
@@ -116,6 +116,19 @@ func TestNotify(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"dryrun true",
+			&Notification{
+				If: "true",
+			},
+			[]NotifyFinding{
+				{
+					SeverityLabel:  types.SeverityLabelCritical,
+					WorkflowStatus: types.WorkflowStatusNew,
+				},
+			},
+			false,
+		},
 	}
 	ctx := context.Background()
 	cfg, err := config.LoadDefaultConfig(ctx)
@@ -135,7 +148,8 @@ func TestNotify(t *testing.T) {
 			tt.notification.WebhookURL = ts.URL
 			sh := New(region)
 			sh.Notifications = append(sh.Notifications, tt.notification)
-			if err := sh.Notify(ctx, cfg, tt.findings); err != nil {
+			dryrun := tt.name == "dryrun true"
+			if err := sh.Notify(ctx, cfg, tt.findings, dryrun); err != nil {
 				t.Error(err)
 			}
 			if len(r.Requests()) == 0 {


### PR DESCRIPTION
If --dryrun is specified for notify, JSON is output to stdout without slack notification

> notify に --dryrun を指定すると、緩やかな通知を行わずに、JSON を標準出力に出力します。

## use case

After setting the exclusion in findings, use -dryrun to make sure that slack notifications are also excluded as intended.

> findings に除外設定を入れた後に、slack 通知でも意図した通りに除外されているかを確かめるために —dryrun を用います

## sample

```sh
$ ./control-controls notify controls/base.yml --overlay controls/foo.yml --stdout
{
  "blocks": [
    {
      "text": {
        "text": "*AWS Security Hub Notification*",
        "type": "mrkdwn"
      },
      "type": "section"
    },
    {
      "text": {
        "text": "CRITICALラベルのコントロールが存在します",
        "type": "mrkdwn"
      },
      "type": "section"
    },
    {
      "fields": [
        {
          "text": "*CRITICAL:*\n2",
          "type": "mrkdwn"
        },
        {
          "text": "*HIGH:*\n51",
          "type": "mrkdwn"
        }
      ],
      "type": "section"
    },
    {
      "fields": [
        {
          "text": "*MEDIUM:*\n203",
          "type": "mrkdwn"
        },
        {
          "text": "*LOW:*\n242",
          "type": "mrkdwn"
        }
      ],
      "type": "section"
    },
    {
      "text": {
        "text": "<https://ap-northeast-1.console.aws.amazon.com/securityhub/home?region=ap-northeast-1#/findings?search=*****|View findings>",
        "type": "mrkdwn"
      },
      "type": "section"
    }
  ]
}

```

